### PR TITLE
Test computed displaywidth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-nose
+mock
+pytest

--- a/test_columnize.py
+++ b/test_columnize.py
@@ -145,6 +145,11 @@ class TestColumize(unittest.TestCase):
         width = computed_displaywidth()
         self.assertEqual(width, 87)
 
+    @mock.patch.dict('os.environ', {'COLUMNS': 'not an int'}, clear=True)
+    def test_computed_displaywidth_environ_COLUMNS_not_an_int(self):
+        width = computed_displaywidth()
+        self.assertEqual(width, 80)
+
     @mock.patch.dict('os.environ', {}, clear=True)
     def test_computed_displaywidth_environ_COLUMNS_unset(self):
         width = computed_displaywidth()

--- a/test_columnize.py
+++ b/test_columnize.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 # -*- Python -*-
 "Unit test for Columnize"
-import operator, os, sys, unittest
+import mock, operator, os, sys, unittest
 
 top_builddir = os.path.join(os.path.dirname(__file__), os.path.pardir)
 if top_builddir[-1] != os.path.sep:
     top_builddir += os.path.sep
 sys.path.insert(0, top_builddir)
 
-from columnize import columnize
+from columnize import columnize, computed_displaywidth
 
 class TestColumize(unittest.TestCase):
 
@@ -139,6 +139,11 @@ class TestColumize(unittest.TestCase):
                       opts={'displaywidth':10, 'arrange_array':True}))
 
         return
+
+    @mock.patch.dict('os.environ', {'COLUMNS': '87'}, clear=True)
+    def test_computed_displaywidth_environ_COLUMNS_set(self):
+        width = computed_displaywidth()
+        self.assertEqual(width, 87)
 
     def test_errors(self):
         """Test various error conditions."""

--- a/test_columnize.py
+++ b/test_columnize.py
@@ -145,6 +145,11 @@ class TestColumize(unittest.TestCase):
         width = computed_displaywidth()
         self.assertEqual(width, 87)
 
+    @mock.patch.dict('os.environ', {}, clear=True)
+    def test_computed_displaywidth_environ_COLUMNS_unset(self):
+        width = computed_displaywidth()
+        self.assertEqual(width, 80)
+
     def test_errors(self):
         """Test various error conditions."""
         self.assertRaises(TypeError, columnize, 5, 'reject input - not array')

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@ filename = columnize.py
 ignore = E123,E127,E203,E221,E225,E226,E231,E241,E251,E701
 
 [testenv]
-deps = pytest
+deps = -r{toxinidir}/requirements.txt
 commands = py.test {posargs}


### PR DESCRIPTION
I thought maybe before working on https://github.com/rocky/pycolumnize/pull/1, we should add some tests...

```
❯ nosetests -s -v
nose.config: INFO: Set working dir to /Users/marca/dev/git-repos/pycolumnize/test
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
Basic sanity and status testing. ... ok
test_computed_displaywidth_environ_COLUMNS_not_an_int (test-basic.TestColumize) ... ok
test_computed_displaywidth_environ_COLUMNS_set (test-basic.TestColumize) ... ok
test_computed_displaywidth_environ_COLUMNS_unset (test-basic.TestColumize) ... ok
Test various error conditions. ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.012s

OK
```