### PR TITLE
.gitignore: Add .eggs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.bak
 /*.egg
+.eggs/
 /*.egg-info
 /*.pyc
 /*~


### PR DESCRIPTION
This is a directory that is created and used by newer versions of setuptools. It uses it to store eggs that it downloads for `setup_requires`, among other things.