### PR TITLE
tox.ini: Add {posargs}

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,4 @@ ignore = E123,E127,E203,E221,E225,E226,E231,E241,E251,E701
 
 [testenv]
 deps = pytest
-commands = py.test
+commands = py.test {posargs}


### PR DESCRIPTION
so user can pass options to py.test from tox command-line.

E.g.:

    tox -e py27 -- -v --maxfail=1 --tb=short -k test_basic