### PR TITLE
tox.ini: Add py32, py33, py34 to envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy
+envlist = py26, py27, py32, py33, py34, pypy
 
 [flake8]
 exclude = .tox,./tmp,./build


### PR DESCRIPTION
```
[marca@marca-mac2 pycolumnize]$ tox
GLOB sdist-make: /Users/marca/dev/git-repos/pycolumnize/setup.py
py26 recreate: /Users/marca/dev/git-repos/pycolumnize/.tox/py26
py26 installdeps: pytest
py26 inst: /Users/marca/dev/git-repos/pycolumnize/.tox/dist/columnize-0.3.6-01.zip
py26 runtests: PYTHONHASHSEED='3813450309'
py26 runtests: commands[0] | py.test
============================================================================= test session starts ==============================================================================
platform darwin -- Python 2.6.8 -- py-1.4.26 -- pytest-2.6.4
collected 2 items

test_columnize.py ..

=========================================================================== 2 passed in 0.05 seconds ===========================================================================
py27 inst-nodeps: /Users/marca/dev/git-repos/pycolumnize/.tox/dist/columnize-0.3.6-01.zip
py27 runtests: PYTHONHASHSEED='3813450309'
py27 runtests: commands[0] | py.test
============================================================================= test session starts ==============================================================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 2 items

test_columnize.py ..

=========================================================================== 2 passed in 0.05 seconds ===========================================================================
py32 recreate: /Users/marca/dev/git-repos/pycolumnize/.tox/py32
py32 installdeps: pytest
py32 inst: /Users/marca/dev/git-repos/pycolumnize/.tox/dist/columnize-0.3.6-01.zip
py32 runtests: PYTHONHASHSEED='3813450309'
py32 runtests: commands[0] | py.test
============================================================================= test session starts ==============================================================================
platform darwin -- Python 3.2.5 -- py-1.4.26 -- pytest-2.6.4
collected 2 items

test_columnize.py ..

=========================================================================== 2 passed in 0.05 seconds ===========================================================================
py33 recreate: /Users/marca/dev/git-repos/pycolumnize/.tox/py33
py33 installdeps: pytest
py33 inst: /Users/marca/dev/git-repos/pycolumnize/.tox/dist/columnize-0.3.6-01.zip
py33 runtests: PYTHONHASHSEED='3813450309'
py33 runtests: commands[0] | py.test
============================================================================= test session starts ==============================================================================
platform darwin -- Python 3.3.3 -- py-1.4.26 -- pytest-2.6.4
collected 2 items

test_columnize.py ..

=========================================================================== 2 passed in 0.07 seconds ===========================================================================
py34 recreate: /Users/marca/dev/git-repos/pycolumnize/.tox/py34
py34 installdeps: pytest
py34 inst: /Users/marca/dev/git-repos/pycolumnize/.tox/dist/columnize-0.3.6-01.zip
py34 runtests: PYTHONHASHSEED='3813450309'
py34 runtests: commands[0] | py.test
============================================================================= test session starts ==============================================================================
platform darwin -- Python 3.4.0 -- py-1.4.26 -- pytest-2.6.4
collected 2 items

test_columnize.py ..

=========================================================================== 2 passed in 0.07 seconds ===========================================================================
pypy recreate: /Users/marca/dev/git-repos/pycolumnize/.tox/pypy
pypy installdeps: pytest
pypy inst: /Users/marca/dev/git-repos/pycolumnize/.tox/dist/columnize-0.3.6-01.zip
pypy runtests: PYTHONHASHSEED='3813450309'
pypy runtests: commands[0] | py.test
============================================================================= test session starts ==============================================================================
platform darwin -- Python 2.7.8[pypy-2.4.0-final] -- py-1.4.26 -- pytest-2.6.4
collected 2 items

test_columnize.py ..

=========================================================================== 2 passed in 0.17 seconds ===========================================================================
___________________________________________________________________________________ summary ____________________________________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  py32: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  pypy: commands succeeded
  congratulations :)
```