### PR TITLE
Add `cover` tox target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 /build
 /dist
 __pycache__
+.coverage
+coverage.xml
+htmlcov/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mock
 pytest
+pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy
+envlist = py26, py27, py32, py33, py34, pypy, cover
 
 [flake8]
 exclude = .tox,./tmp,./build
@@ -9,3 +9,6 @@ ignore = E123,E127,E203,E221,E225,E226,E231,E241,E251,E701
 [testenv]
 deps = -r{toxinidir}/requirements.txt
 commands = py.test {posargs}
+
+[testenv:cover]
+commands = py.test {posargs:--cov pycolumnize.columnize --cov-report=term-missing --cov-report=xml --cov-report=html}


### PR DESCRIPTION
```
❯ tox -e cover
GLOB sdist-make: /Users/marca/dev/git-repos/pycolumnize/setup.py
cover inst-nodeps: /Users/marca/dev/git-repos/pycolumnize/.tox/dist/columnize-0.3.6-01.zip
cover runtests: PYTHONHASHSEED='2308000075'
cover runtests: commands[0] | py.test --cov pycolumnize.columnize --cov-report=term-missing --cov-report=xml --cov-report=html
============================================================================= test session starts ==============================================================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
plugins: cov
collected 5 items

test_columnize.py .....
--------------------------------------------------------------- coverage: platform darwin, python 2.7.6-final-0 ----------------------------------------------------------------
Name        Stmts   Miss  Cover   Missing
-----------------------------------------
columnize     191     45    76%   20, 44, 100, 114, 140, 143, 194, 199, 209, 212, 249, 254, 260-311
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

=========================================================================== 5 passed in 0.18 seconds ===========================================================================
___________________________________________________________________________________ summary ____________________________________________________________________________________
  cover: commands succeeded
  congratulations :)
```