### PR TITLE
Use .coveragerc to exclude lines

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    pass
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ *== *.__main__.:

--- a/columnize.py
+++ b/columnize.py
@@ -260,7 +260,7 @@ def columnize(array, displaywidth=80, colsep = '  ',
     pass
 
 # Demo it
-if __name__=='__main__':  # pragma: no cover
+if __name__=='__main__':
     # from trepan.api import debug
     # debug()
     print(columnize(range(12),


### PR DESCRIPTION
This is more effective and nicer than littering the code with `# pragma: no cover` for every `pass` and such.

```
❯ tox -e cover
GLOB sdist-make: /Users/marca/dev/git-repos/pycolumnize/setup.py
cover inst-nodeps: /Users/marca/dev/git-repos/pycolumnize/.tox/dist/columnize-0.3.6-01.zip
cover runtests: PYTHONHASHSEED='3137508052'
cover runtests: commands[0] | py.test --cov pycolumnize.columnize --cov-report=term-missing --cov-report=xml --cov-report=html
============================================================================= test session starts ==============================================================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
plugins: cov
collected 7 items

test_columnize.py .......
--------------------------------------------------------------- coverage: platform darwin, python 2.7.6-final-0 ----------------------------------------------------------------
Name        Stmts   Miss  Cover   Missing
-----------------------------------------
columnize     142      2    99%   106, 120
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

=========================================================================== 7 passed in 0.16 seconds ===========================================================================
___________________________________________________________________________________ summary ____________________________________________________________________________________
  cover: commands succeeded
  congratulations :)
```