### PR TITLE
Use shutil.get_terminal_size on Python >= 3.3

### DIFF
--- a/columnize.py
+++ b/columnize.py
@@ -5,6 +5,10 @@ array of strings.
 Adapted from the routine of the same name inside cmd.py"""
 
 import os
+try:
+    from shutil import get_terminal_size  # Python >= 3.3
+except ImportError:
+    from backports.shutil_get_terminal_size import get_terminal_size
 
 
 def computed_displaywidth():
@@ -14,21 +18,9 @@ def computed_displaywidth():
     try:
         width = int(os.environ['COLUMNS'])
     except (KeyError, ValueError):
-        width = terminal_width()
+        width = get_terminal_size().columns
 
     return width or 80
-
-
-def terminal_width():
-    try:
-        width = int(os.popen('tput cols').read())
-    except (KeyError, ValueError):
-        try:
-            width = int(os.popen('stty size').read().split()[1])
-        except (IndexError, KeyError, ValueError):
-            width = None
-
-    return width
 
 
 default_opts = {

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,12 @@ from __pkginfo__ import \
 __import__('pkg_resources')
 from setuptools import setup
 
+install_requires = []
+
+import sys
+if sys.version_info < (3, 3):
+    install_requires.append('backports.shutil_get_terminal_size')
+
 setup(
       author             = author,
       author_email       = author_email,
@@ -26,6 +32,7 @@ setup(
       url                = web,
       version            = VERSION,
       py_modules         = py_modules,
+      install_requires   = install_requires,
       setup_requires     = ['nose>=1.0'],
       zip_safe           = zip_safe
       )

--- a/test_columnize.py
+++ b/test_columnize.py
@@ -2,10 +2,6 @@
 # -*- Python -*-
 "Unit test for Columnize"
 import mock, operator, os, sys, unittest
-try:
-    from io import StringIO
-except ImportError:
-    from StringIO import StringIO
 
 top_builddir = os.path.join(os.path.dirname(__file__), os.path.pardir)
 if top_builddir[-1] != os.path.sep:
@@ -148,40 +144,6 @@ class TestColumize(unittest.TestCase):
     def test_computed_displaywidth_environ_COLUMNS_set(self):
         width = computed_displaywidth()
         self.assertEqual(width, 87)
-
-    @mock.patch.dict('os.environ', {'COLUMNS': 'not an int'}, clear=True)
-    @mock.patch('os.popen')
-    def test_computed_displaywidth_environ_COLUMNS_not_an_int(self, mock_popen):
-        mock_popen.return_value = StringIO(b'52'.decode('utf-8'))
-        width = computed_displaywidth()
-        self.assertEqual(width, 52)
-
-    @mock.patch.dict('os.environ', {}, clear=True)
-    @mock.patch('os.popen')
-    def test_computed_displaywidth_environ_COLUMNS_unset(self, mock_popen):
-        mock_popen.return_value = StringIO(b'46'.decode('utf-8'))
-        width = computed_displaywidth()
-        self.assertEqual(width, 46)
-
-    @mock.patch.dict('os.environ', {}, clear=True)
-    @mock.patch('os.popen')
-    def test_computed_displaywidth_tput_fail_stty_ok(self, mock_popen):
-        mock_popen.side_effect = [
-            StringIO(b''.decode('utf-8')),        # tput fails
-            StringIO(b'43 171'.decode('utf-8')),  # stty succeeds
-        ]
-        width = computed_displaywidth()
-        self.assertEqual(width, 171)
-
-    @mock.patch.dict('os.environ', {}, clear=True)
-    @mock.patch('os.popen')
-    def test_computed_displaywidth_tput_fail_stty_fail(self, mock_popen):
-        mock_popen.side_effect = [
-            StringIO(b''.decode('utf-8')),  # tput fails
-            StringIO(b''.decode('utf-8')),  # stty succeeds
-        ]
-        width = computed_displaywidth()
-        self.assertEqual(width, 80)         # 80 is default if all else fails
 
     def test_errors(self):
         """Test various error conditions."""


### PR DESCRIPTION
and backports.shutil_get_terminal_size on Python < 3.3

Fixes #16