### PR TITLE
Nose is only required for tests not installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
       version            = VERSION,
       py_modules         = py_modules,
       install_requires   = install_requires,
-      setup_requires     = ['nose>=1.0'],
+      tests_requires     = ['nose>=1.0'],
       zip_safe           = zip_safe
       )


### PR DESCRIPTION
use tests_requires for test time deps and not setup_requires

Signed-off-by: Justin Lecher <jlec@gentoo.org>