### PR TITLE
Depend on pytest for tests instead of nose

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
       version            = VERSION,
       py_modules         = py_modules,
       install_requires   = install_requires,
-      setup_requires     = ['nose>=1.0'],
+      tests_requires     = ['pytest'],
       zip_safe           = zip_safe
       )


### PR DESCRIPTION
The project switched to pytest so there is no need to depend on nose anymore

Signed-off-by: Justin Lecher jlec@gentoo.org
