### PR TITLE
Fix crash when the displayWidth is too small for two columns

### DIFF
--- a/columnize.py
+++ b/columnize.py
@@ -118,7 +118,7 @@ def columnize(array, displaywidth=80, colsep = '  ',
     if o['arrange_vertical']:
         array_index = lambda nrows, row, col: nrows*col + row
         # Try every row count from 1 upwards
-        for nrows in range(1, size):
+        for nrows in range(1, size+1):
             ncols = (size+nrows-1) // nrows
             colwidths = []
             totwidth = -len(o['colsep'])

--- a/test_columnize.py
+++ b/test_columnize.py
@@ -151,7 +151,7 @@ class TestColumize(unittest.TestCase):
                          columnize([0, 1, 2, 3], 7,
                                    arrange_vertical=False,
                                    opts={'colfmt': '%5d',
-                                         'displaywidth': 17,
+                                         'displaywidth': 16,
                                          'lineprefix': '>>>   '}))
 
     @mock.patch.dict('os.environ', {'COLUMNS': '87'}, clear=True)

--- a/test_columnize.py
+++ b/test_columnize.py
@@ -147,7 +147,7 @@ class TestColumize(unittest.TestCase):
                                    opts={'colfmt': '%5d'}))
 
     def test_lineprefix(self):
-        self.assertEqual('>>>       0      3\n>>>       1\n>>>       2\n',
+        self.assertEqual('>>>       0\n>>>       1\n>>>       2\n>>>       3\n',
                          columnize([0, 1, 2, 3], 7,
                                    arrange_vertical=False,
                                    opts={'colfmt': '%5d',


### PR DESCRIPTION
It is a degenerate case, but if there is no solution with more than one column, the algorithm currently dies trying to look up the width of the non-existent second column.
```
File "/Users/tyler/.pyenv/versions/3.5.1/lib/python3.5/site-packages/columnize.py", line 162, in columnize
    texts[col] = texts[col].rjust(colwidths[col])
IndexError: list index out of range
```

Allowing the algorithm to try the solution with all the rows in one column returns a solution that might be too wide for the display (displayWidth < the length of the longest entry in the list) but it doesn't crash.