### PR TITLE
modernize pycolumnize code to support python-3.8 to python-3.15

### DIFF
--- a/__pkginfo__.py
+++ b/__pkginfo__.py
@@ -12,23 +12,15 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Topic :: Software Development :: Libraries :: Python Modules",
-    "Programming Language :: Python :: 2.4",
-    "Programming Language :: Python :: 2.5",
-    "Programming Language :: Python :: 2.6",
-    "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.1",
-    "Programming Language :: Python :: 3.2",
-    "Programming Language :: Python :: 3.3",
-    "Programming Language :: Python :: 3.4",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12 ",
-    "Programming Language :: Python :: 3.13 ",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
 ]
 
 
@@ -41,6 +33,7 @@ def read(*rnames):
     return open(osp.join(get_srcdir(), *rnames)).read()
 
 
+__version__: str = ""
 exec(read("columnize/version.py"))
 
 # The rest in alphabetic order

--- a/columnize/__main__.py
+++ b/columnize/__main__.py
@@ -4,17 +4,16 @@ array of strings.
 
 Adapted from the routine of the same name inside cmd.py"""
 
-import os
+from __future__ import annotations
 
-# Python >= 3.3
-# older Python's use
-# from backports.shutil_get_terminal_size import get_terminal_size
+import os
 from shutil import get_terminal_size
+from typing import Any
 
 DEFAULT_WIDTH = 80
 
 
-def computed_displaywidth():
+def computed_displaywidth() -> int:
     """Figure out a reasonable default with. Use os.environ['COLUMNS'] if possible,
     and failing that use 80.
     """
@@ -23,13 +22,13 @@ def computed_displaywidth():
     except (KeyError, ValueError):
         try:
             width = get_terminal_size().columns
-        except:  # noqa
+        except Exception:
             width = DEFAULT_WIDTH
 
     return width or DEFAULT_WIDTH
 
 
-default_opts = {
+default_opts: dict[str, Any] = {
     "arrange_array": False,  # Check if file has changed since last time
     "arrange_vertical": True,
     "array_prefix": "",
@@ -44,19 +43,19 @@ default_opts = {
 }
 
 
-def get_option(key, options):
+def get_option(key: str, options: dict[str, Any]) -> Any:
     return options.get(key, default_opts.get(key))
 
 
 def columnize(
-    array,
-    displaywidth=80,
-    colsep="  ",
-    arrange_vertical=True,
-    ljust=True,
-    lineprefix="",
-    opts=None,
-):
+    array: list[Any] | tuple[Any, ...],
+    displaywidth: int = 80,
+    colsep: str = "  ",
+    arrange_vertical: bool = True,
+    ljust: bool | None = True,
+    lineprefix: str = "",
+    opts: dict[str, Any] | None = None,
+) -> str:
     """Return a list of strings as a compact set of columns arranged
     horizontally or vertically.
 
@@ -78,13 +77,12 @@ def columnize(
     if opts is None:
         opts = {}
     if not isinstance(array, (list, tuple)):
-        raise TypeError(("array needs to be an instance of a list or a tuple"))
+        raise TypeError("array needs to be an instance of a list or a tuple")
 
-    o = {}
+    o: dict[str, Any] = {}
     if len(opts.keys()) > 0:
         for key in default_opts.keys():
             o[key] = get_option(key, opts)
-            pass
         if o["arrange_array"]:
             o["array_prefix"] = "["
             o["lineprefix"] = " "
@@ -92,7 +90,6 @@ def columnize(
             o["array_suffix"] = "]\n"
             o["colsep"] = ", "
             o["arrange_vertical"] = False
-            pass
 
     else:
         o = default_opts.copy()
@@ -101,28 +98,27 @@ def columnize(
         o["arrange_vertical"] = arrange_vertical
         o["ljust"] = ljust
         o["lineprefix"] = lineprefix
-        pass
 
     # if o['ljust'] is None:
     #     o['ljust'] = !(list.all?{|datum| datum.kind_of?(Numeric)})
-    #     pass
 
     if o["colfmt"]:
-        array = [(o["colfmt"] % i) for i in array]
+        formatted_array = [(o["colfmt"] % i) for i in array]
     else:
-        array = [str(i) for i in array]
-        pass
+        formatted_array = [str(i) for i in array]
 
     # Some degenerate cases
-    size = len(array)
+    size = len(formatted_array)
     if 0 == size:
         return "<empty>\n"
     elif size == 1:
-        return "%s%s%s\n" % (o["array_prefix"], str(array[0]), o["array_suffix"])
+        return f"{o['array_prefix']}{formatted_array[0]}{o['array_suffix']}\n"
 
     o["displaywidth"] = max(4, o["displaywidth"] - len(o["lineprefix"]))
     if o["arrange_vertical"]:
-        array_index = lambda nrows, row, col: nrows * col + row
+        def array_index(dim: int, row: int, col: int) -> int:
+            return dim * col + row
+
         # Try every row count from 1 upwards
         for nrows in range(1, size + 1):
             ncols = (size + nrows - 1) // nrows
@@ -135,17 +131,14 @@ def columnize(
                     i = array_index(nrows, row, col)
                     if i >= size:
                         break
-                    x = array[i]
+                    x = formatted_array[i]
                     colwidth = max(colwidth, len(x))
-                    pass
                 colwidths.append(colwidth)
                 totwidth += colwidth + len(o["colsep"])
                 if totwidth > o["displaywidth"]:
                     break
-                pass
             if totwidth <= o["displaywidth"]:
                 break
-            pass
         # The smallest number of rows computed and the
         # max widths for each column has been obtained.
         # Now we just have to format each of the
@@ -158,7 +151,7 @@ def columnize(
                 if i >= size:
                     x = ""
                 else:
-                    x = array[i]
+                    x = formatted_array[i]
                 texts.append(x)
             while texts and not texts[-1]:
                 del texts[-1]
@@ -167,19 +160,15 @@ def columnize(
                     texts[col] = texts[col].ljust(colwidths[col])
                 else:
                     texts[col] = texts[col].rjust(colwidths[col])
-                    pass
-                pass
-            s += "%s%s%s" % (
-                o["lineprefix"],
-                str(o["colsep"].join(texts)),
-                o["linesuffix"],
-            )
-            pass
+            s += f"{o['lineprefix']}{o['colsep'].join(texts)}{o['linesuffix']}"
         return s
     else:
-        array_index = lambda ncols, row, col: ncols * (row - 1) + col
+        def array_index(dim: int, row: int, col: int) -> int:
+            return dim * (row - 1) + col
+
         # Try every column count from size downwards
         colwidths = []
+        i = 0
         for ncols in range(size, 0, -1):
             # Try every row count from 1 upwards
             min_rows = (size + ncols - 1) // ncols
@@ -197,15 +186,12 @@ def columnize(
                         if i >= rounded_size:
                             break
                         elif i < size:
-                            x = array[i]
+                            x = formatted_array[i]
                             colwidth = max(colwidth, len(x))
-                            pass
-                        pass
                     colwidths.append(colwidth)
                     totwidth += colwidth + len(o["colsep"])
                     if totwidth >= o["displaywidth"]:
                         break
-                    pass
                 if totwidth <= o["displaywidth"] and i >= rounded_size - 1:
                     # Found the right nrows and ncols
                     # print "right nrows and ncols"
@@ -215,10 +201,8 @@ def columnize(
                     # print "reduce ncols", ncols
                     # Need to reduce ncols
                     break
-                pass
             if totwidth <= o["displaywidth"] and i >= rounded_size - 1:
                 break
-            pass
         # The smallest number of rows computed and the
         # max widths for each column has been obtained.
         # Now we just have to format each of the
@@ -228,7 +212,6 @@ def columnize(
             prefix = o["array_prefix"]
         else:
             prefix = o["lineprefix"]
-            pass
         for row in range(1, nrows + 1):
             texts = []
             for col in range(ncols):
@@ -236,29 +219,22 @@ def columnize(
                 if i >= size:
                     break
                 else:
-                    x = array[i]
+                    x = formatted_array[i]
                 texts.append(x)
-                pass
             for col in range(len(texts)):
                 if o["ljust"]:
                     texts[col] = texts[col].ljust(colwidths[col])
                 else:
                     texts[col] = texts[col].rjust(colwidths[col])
-                    pass
-                pass
-            s += "%s%s%s" % (prefix, str(o["colsep"].join(texts)), o["linesuffix"])
+            s += f"{prefix}{o['colsep'].join(texts)}{o['linesuffix']}"
             prefix = o["lineprefix"]
-            pass
         if o["arrange_array"]:
             colsep = o["colsep"].rstrip()
             colsep_pos = -(len(colsep) + 1)
             if s[colsep_pos:] == colsep + "\n":
                 s = s[:colsep_pos] + o["array_suffix"] + "\n"
-                pass
-            pass
         else:
             s += o["array_suffix"]
-            pass
         return s
     pass
 
@@ -363,7 +339,7 @@ if __name__ == "__main__":
     import sys
 
     try:
-        print(columnize(5))
+        print(columnize(5))  # type: ignore[arg-type]
     except TypeError:
         err = sys.exc_info()[1]
         print(err)

--- a/columnize/version.py
+++ b/columnize/version.py
@@ -5,4 +5,4 @@
 # debugger version number.
 
 # fmt: off
-__version__="0.3.12.dev0" # noqa
+__version__="0.3.15" # noqa

--- a/example2.py
+++ b/example2.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Example usage of the columnize library."""
+
+from columnize import __version__, columnize
+
+print(f"Columnize version: {__version__}\n")
+
+# 1. Basic formatting (arrange vertically, default separator '  ')
+print("--- 1. Basic Vertical Formatting ---")
+data = [f"Item-{i}" for i in range(1, 13)]
+result = columnize(data, displaywidth=40)
+print(result)
+
+# 2. Horizontal formatting
+print("--- 2. Horizontal Formatting ---")
+result_horizontal = columnize(data, displaywidth=40, arrange_vertical=False)
+print(result_horizontal)
+
+# 3. Custom column separator and custom line prefix
+print("--- 3. Custom Column Separator & Line Prefix ---")
+result_custom = columnize(
+    data,
+    displaywidth=45,
+    colsep=" | ",
+    lineprefix=">> ",
+)
+print(result_custom)
+
+# 4. Numeric data with right justification (ljust=False)
+print("--- 4. Right Justified Numeric Data ---")
+numbers = [str(10**i) for i in range(7)]
+result_numbers = columnize(numbers, displaywidth=30, ljust=False, colsep="  ")
+print(result_numbers)
+
+# 5. Using the arrange_array option
+print("--- 5. Formatted as an Array ---")
+result_array = columnize(
+    list(range(20)),
+    opts={"displaywidth": 40, "arrange_array": True},
+)
+print(result_array)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ distutils setup (setup.py)
 This gets a bit of package info from __pkginfo__.py file
 """
 # Get the required package information
-from setuptools import find_packages, setup
+from setuptools import find_packages, setup  # type: ignore[import-untyped]
 
 from __pkginfo__ import (
     __version__,

--- a/test/test_columnize.py
+++ b/test/test_columnize.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- Python -*-
 "Unit test for Columnize"
-import sys
 from unittest import mock
+
 
 import pytest
 
@@ -175,14 +175,12 @@ def test_lineprefix_just_wide_enough():
     )
 
 
-if sys.version_info[:2] >= (3, 6):
+@mock.patch.dict("os.environ", {"COLUMNS": "87"}, clear=True)
+def test_computed_displaywidth_environ_columns_set():
+    from columnize import computed_displaywidth
 
-    @mock.patch.dict("os.environ", {"COLUMNS": "87"}, clear=True)
-    def test_computed_displaywidth_environ_columns_set():
-        from columnize import computed_displaywidth
-
-        width = computed_displaywidth()
-        assert width == 87
+    width = computed_displaywidth()
+    assert width == 87
 
 
 def test_errors():


### PR DESCRIPTION
- modernize pycolumnize code to support python-3.8 to python-3.15

- this PR is split in 6 small commits, also bump the version to 0.3.15 and add another example example2.py

- validated the code and it's tests against Python 3.15.0b3 (Fedora rawhide)

@rocky  could you please check once you have time ?

====
wip/dev/pycolumnize$ python3 --version
Python 3.15.0b3

wip/dev/pycolumnize$ python3 example2.py
Columnize version: 0.3.15

--- 1. Basic Vertical Formatting ---
Item-1  Item-4  Item-7  Item-10
Item-2  Item-5  Item-8  Item-11
Item-3  Item-6  Item-9  Item-12

--- 2. Horizontal Formatting ---
Item-1  Item-2   Item-3   Item-4
Item-5  Item-6   Item-7   Item-8
Item-9  Item-10  Item-11  Item-12

--- 3. Custom Column Separator & Line Prefix ---
>> Item-1 | Item-4 | Item-7 | Item-10
>> Item-2 | Item-5 | Item-8 | Item-11
>> Item-3 | Item-6 | Item-9 | Item-12

--- 4. Right Justified Numeric Data ---
 1   100   10000  1000000
10  1000  100000

--- 5. Formatted as an Array ---
[ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]


wip/dev/pycolumnize$ date
Thu Jun 25 07:40:58 PM -03 2026
